### PR TITLE
[DEV] Android Talk UI 구성

### DIFF
--- a/app/src/main/java/com/gdsc_cau/vridge/main/MainBottomBar.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/main/MainBottomBar.kt
@@ -1,15 +1,12 @@
 package com.gdsc_cau.vridge.main
 
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideIn
-import androidx.compose.animation.slideOut
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -17,10 +14,8 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.selectable
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -29,7 +24,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -41,8 +35,20 @@ fun MainBottomBar(
 ) {
     AnimatedVisibility(
         visible = visible,
-        enter = fadeIn() + slideIn { IntOffset(0, it.height) },
-        exit = fadeOut() + slideOut { IntOffset(0, it.height) }
+        enter =
+            fadeIn(
+                animationSpec =
+                    keyframes {
+                        this.durationMillis = 0
+                    }
+            ),
+        exit =
+            fadeOut(
+                animationSpec =
+                    keyframes {
+                        this.durationMillis = 0
+                    }
+            )
     ) {
         Row(
             modifier =

--- a/app/src/main/java/com/gdsc_cau/vridge/main/MainScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/main/MainScreen.kt
@@ -35,7 +35,7 @@ fun MainScreen(
                         .fillMaxSize()
                         .background(MaterialTheme.colorScheme.background)
                         .padding(padding)
-                        .padding(horizontal = 8.dp, vertical = 8.dp)
+                        .padding(vertical = 8.dp)
             ) {
                 NavHost(
                     navController = navigator.navController,
@@ -72,7 +72,7 @@ fun MainScreen(
         },
         topBar = {
             MainTopBar(
-                title = navigator.currentTab?.title ?: "",
+                title = navigator.currentTab?.title ?: ""
             )
         },
         bottomBar = {

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -1,9 +1,15 @@
 package com.gdsc_cau.vridge.talk
 
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.CardDefaults
@@ -13,6 +19,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -27,9 +34,30 @@ private enum class VoiceState {
 fun TalkScreen(
     sessionId: String
 ) {
-    Column {
+    TalkHistory()
+    TalkInput {}
+}
+
+@Composable
+fun TalkHistory() {
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(bottom = 60.dp)
+                .verticalScroll(ScrollState(Int.MAX_VALUE)),
+        verticalArrangement = Arrangement.Bottom
+    ) {
         TalkCard()
-        TalkInput {}
+        TalkCard()
+        TalkCard()
+        TalkCard()
+        TalkCard()
+        TalkCard()
+        TalkCard()
+        TalkCard()
+        TalkCard()
+        TalkCard()
     }
 }
 
@@ -54,24 +82,37 @@ fun TalkCard() {
             modifier =
                 Modifier
                     .padding(all = 15.dp),
-            text = "This is Talk Card Content"
+            text = "This is Talk Card Content\nThis is Talk Card Content"
         )
     }
 }
 
 @Composable
 fun TalkInput(onClicked: () -> Unit) {
-    Row {
+    Row(
+        modifier =
+            Modifier
+                .fillMaxSize(),
+        verticalAlignment = Alignment.Bottom
+    ) {
         TextField(
+            modifier =
+                Modifier
+                    .height(50.dp)
+                    .weight(1f),
             value = "",
             onValueChange = {}
         )
         IconButton(
+            modifier =
+                Modifier
+                    .height(45.dp)
+                    .width(45.dp),
             onClick = onClicked
         ) {
             Icon(
                 imageVector = Icons.Filled.Send,
-                contentDescription = ""
+                contentDescription = "Send Button"
             )
         }
     }

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Send
@@ -17,8 +18,11 @@ import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -91,19 +95,28 @@ private fun TalkCard(talkData: String, talkState: VoiceState) {
 
 @Composable
 fun TalkInput(onClicked: () -> Unit) {
+    var data by remember {
+        mutableStateOf("")
+    }
+
     Row(
         modifier =
             Modifier
                 .fillMaxSize(),
         verticalAlignment = Alignment.Bottom
     ) {
-        TextField(
+        BasicTextField(
             modifier =
                 Modifier
                     .height(50.dp)
                     .weight(1f),
-            value = "",
-            onValueChange = {}
+            value = data,
+            onValueChange = { input ->
+                data = input
+            },
+            decorationBox = { innerTextField ->
+                TalkInputDecor(innerTextField)
+            }
         )
         IconButton(
             modifier =
@@ -117,5 +130,14 @@ fun TalkInput(onClicked: () -> Unit) {
                 contentDescription = "Send Button"
             )
         }
+    }
+}
+
+@Composable
+fun TalkInputDecor(innerTextField: @Composable () -> Unit) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        innerTextField()
     }
 }

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -48,7 +48,7 @@ fun TalkHistory() {
         modifier =
             Modifier
                 .fillMaxSize()
-                .padding(bottom = 60.dp)
+                .padding(bottom = 45.dp)
                 .verticalScroll(ScrollState(Int.MAX_VALUE)),
         verticalArrangement = Arrangement.Bottom
     ) {

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -209,7 +209,7 @@ fun TalkInputDecor(innerTextField: @Composable () -> Unit) {
                 contentAlignment = Alignment.CenterStart,
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(start = 10.dp, end = 10.dp, top = 5.dp, bottom = 5.dp),
+                    .padding(horizontal = 10.dp, vertical = 5.dp),
             ) {
                 innerTextField()
             }

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -44,17 +44,19 @@ private enum class VoiceState {
     VOICE_READY
 }
 
-private val dummyTalkTextData: Array<String> = arrayOf(
-    "This is Talk Card Content\nThis is Talk Card Content\nThis is Talk Card Content\nContent Ready",
-    "This is Talk Card Content\nThis is Talk Card Content\nContent Playing",
-    "This is Talk Card Content\nContent Loading"
-)
+private val dummyTalkTextData: Array<String> =
+    arrayOf(
+        "This is Talk Card Content\nThis is Talk Card Content\nThis is Talk Card Content\nContent Ready",
+        "This is Talk Card Content\nThis is Talk Card Content\nContent Playing",
+        "This is Talk Card Content\nContent Loading"
+    )
 
-private val dummyTalkStateData: Array<VoiceState> = arrayOf(
-    VoiceState.VOICE_READY,
-    VoiceState.VOICE_PLAYING,
-    VoiceState.VOICE_LOADING
-)
+private val dummyTalkStateData: Array<VoiceState> =
+    arrayOf(
+        VoiceState.VOICE_READY,
+        VoiceState.VOICE_PLAYING,
+        VoiceState.VOICE_LOADING
+    )
 
 @Composable
 fun TalkScreen(
@@ -69,10 +71,11 @@ fun TalkScreen(
 @Composable
 fun TalkHistory() {
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(bottom = 75.dp)
-            .verticalScroll(ScrollState(Int.MAX_VALUE)),
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(bottom = 75.dp)
+                .verticalScroll(ScrollState(Int.MAX_VALUE)),
         verticalArrangement = Arrangement.Bottom
     ) {
         TalkCard(talkData = dummyTalkTextData[0], voiceState = dummyTalkStateData[0])
@@ -94,21 +97,24 @@ private fun TalkCard(talkData: String, voiceState: VoiceState) {
             ),
         elevation =
             CardDefaults.cardElevation(
-                defaultElevation = 8.dp
+                defaultElevation = 4.dp
             ),
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(IntrinsicSize.Min)
-            .padding(all = 15.dp)
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(IntrinsicSize.Min)
+                .padding(all = 15.dp)
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
+            modifier =
+                Modifier
+                    .fillMaxWidth()
         ) {
             Box(
-                modifier = Modifier
-                    .padding(all = 15.dp)
-                    .weight(1f),
+                modifier =
+                    Modifier
+                        .padding(all = 15.dp)
+                        .weight(1f)
             ) {
                 Text(text = talkData)
             }
@@ -122,16 +128,20 @@ private fun TextCardController(voiceState: VoiceState) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
-        modifier = Modifier
-            .background(
-                if (voiceState == VoiceState.VOICE_LOADING) Grey3
-                else PrimaryUpperLight
-            )
-            .fillMaxHeight()
-            .width(50.dp)
-            .clickable {
-                // TODO: Call Control Function
-            }
+        modifier =
+            Modifier
+                .background(
+                    if (voiceState == VoiceState.VOICE_LOADING) {
+                        Grey3
+                    } else {
+                        PrimaryUpperLight
+                    }
+                )
+                .fillMaxHeight()
+                .width(50.dp)
+                .clickable {
+                    // TODO: Call Control Function
+                }
     ) {
         Icon(
             painter =
@@ -140,7 +150,7 @@ private fun TextCardController(voiceState: VoiceState) {
                         VoiceState.VOICE_LOADING -> R.drawable.ic_downloading
                         VoiceState.VOICE_PLAYING -> R.drawable.ic_play_stop
                         else -> R.drawable.ic_play_arrow
-                    },
+                    }
                 ),
             contentDescription = "Play Button"
         )
@@ -160,9 +170,10 @@ fun TalkInput(onSendClicked: () -> Unit) {
         verticalAlignment = Alignment.Bottom
     ) {
         BasicTextField(
-            modifier = Modifier
-                .height(60.dp)
-                .weight(1f),
+            modifier =
+                Modifier
+                    .height(60.dp)
+                    .weight(1f),
             value = data,
             onValueChange = { input ->
                 data = input
@@ -173,18 +184,21 @@ fun TalkInput(onSendClicked: () -> Unit) {
         )
         Box(
             contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .height(60.dp)
-                .width(60.dp)
+            modifier =
+                Modifier
+                    .height(60.dp)
+                    .width(60.dp)
         ) {
             IconButton(
-                colors = IconButtonDefaults.iconButtonColors(
-                    containerColor = Grey3,
-                    contentColor = Black
-                ),
-                modifier = Modifier
-                    .height(50.dp)
-                    .width(50.dp),
+                colors =
+                    IconButtonDefaults.iconButtonColors(
+                        containerColor = Grey3,
+                        contentColor = Black
+                    ),
+                modifier =
+                    Modifier
+                        .height(50.dp)
+                        .width(50.dp),
                 onClick = onSendClicked
             ) {
                 Icon(
@@ -193,7 +207,6 @@ fun TalkInput(onSendClicked: () -> Unit) {
                 )
             }
         }
-
     }
 }
 
@@ -208,16 +221,18 @@ fun TalkInputDecor(innerTextField: @Composable () -> Unit) {
                     containerColor = White,
                     contentColor = Black
                 ),
-            modifier = Modifier
-                .background(White)
-                .fillMaxSize()
-                .padding(all = 5.dp)
+            modifier =
+                Modifier
+                    .background(White)
+                    .fillMaxSize()
+                    .padding(all = 5.dp)
         ) {
             Box(
                 contentAlignment = Alignment.CenterStart,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 10.dp, vertical = 5.dp),
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 10.dp, vertical = 5.dp)
             ) {
                 innerTextField()
             }

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -61,7 +61,9 @@ fun TalkScreen(
     sessionId: String
 ) {
     TalkHistory()
-    TalkInput(onSendClicked = {})
+    TalkInput(onSendClicked = {
+        // TODO: Send Talk to API
+    })
 }
 
 @Composable

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -48,21 +48,23 @@ fun TalkHistory() {
                 .verticalScroll(ScrollState(Int.MAX_VALUE)),
         verticalArrangement = Arrangement.Bottom
     ) {
-        TalkCard()
-        TalkCard()
-        TalkCard()
-        TalkCard()
-        TalkCard()
-        TalkCard()
-        TalkCard()
-        TalkCard()
-        TalkCard()
-        TalkCard()
+        TalkCard(
+            talkData = "This is Talk Card Content\nContent Ready",
+            talkState = VoiceState.VOICE_READY
+        )
+        TalkCard(
+            talkData = "This is Talk Card Content\nContent Playing",
+            talkState = VoiceState.VOICE_PLAYING
+        )
+        TalkCard(
+            talkData = "This is Talk Card Content\nContent Loading",
+            talkState = VoiceState.VOICE_LOADING
+        )
     }
 }
 
 @Composable
-fun TalkCard() {
+private fun TalkCard(talkData: String, talkState: VoiceState) {
     ElevatedCard(
         colors =
             CardDefaults.cardColors(
@@ -82,7 +84,7 @@ fun TalkCard() {
             modifier =
                 Modifier
                     .padding(all = 15.dp),
-            text = "This is Talk Card Content\nThis is Talk Card Content"
+            text = talkData
         )
     }
 }

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
@@ -33,7 +32,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
+import com.gdsc_cau.vridge.R
 import com.gdsc_cau.vridge.ui.theme.Black
 import com.gdsc_cau.vridge.ui.theme.Grey3
 import com.gdsc_cau.vridge.ui.theme.PrimaryUpperLight
@@ -117,8 +118,9 @@ private fun TextCardController(voiceState: VoiceState) {
         verticalArrangement = Arrangement.Center,
         modifier = Modifier
             .background(
-                if(voiceState == VoiceState.VOICE_LOADING) Grey3
-                else PrimaryUpperLight)
+                if (voiceState == VoiceState.VOICE_LOADING) Grey3
+                else PrimaryUpperLight
+            )
             .fillMaxHeight()
             .width(50.dp)
             .clickable {
@@ -126,12 +128,14 @@ private fun TextCardController(voiceState: VoiceState) {
             }
     ) {
         Icon(
-            imageVector =
-                when (voiceState) {
-                    VoiceState.VOICE_LOADING -> Icons.Filled.PlayArrow
-                    VoiceState.VOICE_PLAYING -> Icons.Filled.PlayArrow
-                    else -> Icons.Filled.PlayArrow
-                },
+            painter =
+                painterResource(
+                    when (voiceState) {
+                        VoiceState.VOICE_LOADING -> R.drawable.ic_downloading
+                        VoiceState.VOICE_PLAYING -> R.drawable.ic_play_stop
+                        else -> R.drawable.ic_play_arrow
+                    },
+                ),
             contentDescription = "Play Button"
         )
     }

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -44,6 +44,18 @@ private enum class VoiceState {
     VOICE_READY
 }
 
+private val dummyTalkTextData: Array<String> = arrayOf(
+    "This is Talk Card Content\nThis is Talk Card Content\nThis is Talk Card Content\nContent Ready",
+    "This is Talk Card Content\nThis is Talk Card Content\nContent Playing",
+    "This is Talk Card Content\nContent Loading"
+)
+
+private val dummyTalkStateData: Array<VoiceState> = arrayOf(
+    VoiceState.VOICE_READY,
+    VoiceState.VOICE_PLAYING,
+    VoiceState.VOICE_LOADING
+)
+
 @Composable
 fun TalkScreen(
     sessionId: String
@@ -61,18 +73,12 @@ fun TalkHistory() {
             .verticalScroll(ScrollState(Int.MAX_VALUE)),
         verticalArrangement = Arrangement.Bottom
     ) {
-        TalkCard(
-            talkData = "This is Talk Card Content\nThis is Talk Card Content\nThis is Talk Card Content\nContent Ready",
-            voiceState = VoiceState.VOICE_READY
-        )
-        TalkCard(
-            talkData = "This is Talk Card Content\nThis is Talk Card Content\nContent Playing",
-            voiceState = VoiceState.VOICE_PLAYING
-        )
-        TalkCard(
-            talkData = "This is Talk Card Content\nContent Loading",
-            voiceState = VoiceState.VOICE_LOADING
-        )
+        TalkCard(talkData = dummyTalkTextData[0], voiceState = dummyTalkStateData[0])
+        TalkCard(talkData = dummyTalkTextData[1], voiceState = dummyTalkStateData[1])
+        TalkCard(talkData = dummyTalkTextData[2], voiceState = dummyTalkStateData[2])
+        TalkCard(talkData = dummyTalkTextData[0], voiceState = dummyTalkStateData[0])
+        TalkCard(talkData = dummyTalkTextData[1], voiceState = dummyTalkStateData[1])
+        TalkCard(talkData = dummyTalkTextData[2], voiceState = dummyTalkStateData[2])
     }
 }
 

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -1,10 +1,16 @@
 package com.gdsc_cau.vridge.talk
 
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -36,5 +42,23 @@ fun TalkCard() {
                 .height(40.dp)
     ) {
         Text(text = "Talk Card")
+    }
+}
+
+@Composable
+fun TalkInput(message: String, onClicked: () -> Unit) {
+    Row {
+        TextField(
+            value = "",
+            onValueChange = {}
+        )
+        IconButton(
+            onClick = onClicked
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Send,
+                contentDescription = ""
+            )
+        }
     }
 }

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -58,11 +58,11 @@ fun TalkHistory() {
         verticalArrangement = Arrangement.Bottom
     ) {
         TalkCard(
-            talkData = "This is Talk Card Content\nContent Ready",
+            talkData = "This is Talk Card Content\nThis is Talk Card Content\nThis is Talk Card Content\nContent Ready",
             talkState = VoiceState.VOICE_READY
         )
         TalkCard(
-            talkData = "This is Talk Card Content\nContent Playing",
+            talkData = "This is Talk Card Content\nThis is Talk Card Content\nContent Playing",
             talkState = VoiceState.VOICE_PLAYING
         )
         TalkCard(

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -2,10 +2,13 @@ package com.gdsc_cau.vridge.talk
 
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -14,6 +17,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
@@ -32,6 +36,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.gdsc_cau.vridge.ui.theme.Black
 import com.gdsc_cau.vridge.ui.theme.Grey3
+import com.gdsc_cau.vridge.ui.theme.PrimaryUpperLight
 import com.gdsc_cau.vridge.ui.theme.White
 
 private enum class VoiceState {
@@ -59,21 +64,21 @@ fun TalkHistory() {
     ) {
         TalkCard(
             talkData = "This is Talk Card Content\nThis is Talk Card Content\nThis is Talk Card Content\nContent Ready",
-            talkState = VoiceState.VOICE_READY
+            voiceState = VoiceState.VOICE_READY
         )
         TalkCard(
             talkData = "This is Talk Card Content\nThis is Talk Card Content\nContent Playing",
-            talkState = VoiceState.VOICE_PLAYING
+            voiceState = VoiceState.VOICE_PLAYING
         )
         TalkCard(
             talkData = "This is Talk Card Content\nContent Loading",
-            talkState = VoiceState.VOICE_LOADING
+            voiceState = VoiceState.VOICE_LOADING
         )
     }
 }
 
 @Composable
-private fun TalkCard(talkData: String, talkState: VoiceState) {
+private fun TalkCard(talkData: String, voiceState: VoiceState) {
     ElevatedCard(
         colors =
             CardDefaults.cardColors(
@@ -86,12 +91,48 @@ private fun TalkCard(talkData: String, talkState: VoiceState) {
             ),
         modifier = Modifier
             .fillMaxWidth()
+            .height(IntrinsicSize.Min)
             .padding(all = 15.dp)
     ) {
-        Text(
+        Row(
             modifier = Modifier
-                .padding(all = 15.dp),
-            text = talkData
+                .fillMaxWidth()
+        ) {
+            Box(
+                modifier = Modifier
+                    .padding(all = 15.dp)
+                    .weight(1f),
+            ) {
+                Text(text = talkData)
+            }
+            TextCardController(voiceState = voiceState)
+        }
+    }
+}
+
+@Composable
+private fun TextCardController(voiceState: VoiceState) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .background(
+                if(voiceState == VoiceState.VOICE_LOADING) Grey3
+                else PrimaryUpperLight)
+            .fillMaxHeight()
+            .width(50.dp)
+            .clickable {
+                // TODO: Call Control Function
+            }
+    ) {
+        Icon(
+            imageVector =
+                when (voiceState) {
+                    VoiceState.VOICE_LOADING -> Icons.Filled.PlayArrow
+                    VoiceState.VOICE_PLAYING -> Icons.Filled.PlayArrow
+                    else -> Icons.Filled.PlayArrow
+                },
+            contentDescription = "Play Button"
         )
     }
 }

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -1,6 +1,5 @@
 package com.gdsc_cau.vridge.talk
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -37,13 +36,17 @@ fun TalkScreen(
 @Composable
 fun TalkCard() {
     ElevatedCard(
+        colors =
+            CardDefaults.cardColors(
+                containerColor = Color.White,
+                contentColor = Color.Black
+            ),
         elevation =
             CardDefaults.cardElevation(
                 defaultElevation = 8.dp
             ),
         modifier =
             Modifier
-                .background(color = Color.White)
                 .fillMaxWidth()
                 .padding(all = 15.dp)
     ) {

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,9 +29,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gdsc_cau.vridge.ui.theme.Black
+import com.gdsc_cau.vridge.ui.theme.Grey3
 import com.gdsc_cau.vridge.ui.theme.White
 
 private enum class VoiceState {
@@ -39,10 +40,9 @@ private enum class VoiceState {
     VOICE_READY
 }
 
-@Preview
 @Composable
 fun TalkScreen(
-//    sessionId: String
+    sessionId: String
 ) {
     TalkHistory()
     TalkInput {}
@@ -52,10 +52,10 @@ fun TalkScreen(
 fun TalkHistory() {
     Column(
         modifier =
-            Modifier
-                .fillMaxSize()
-                .padding(bottom = 55.dp)
-                .verticalScroll(ScrollState(Int.MAX_VALUE)),
+        Modifier
+            .fillMaxSize()
+            .padding(bottom = 75.dp)
+            .verticalScroll(ScrollState(Int.MAX_VALUE)),
         verticalArrangement = Arrangement.Bottom
     ) {
         TalkCard(
@@ -114,7 +114,7 @@ fun TalkInput(onClicked: () -> Unit) {
         BasicTextField(
             modifier =
                 Modifier
-                    .height(50.dp)
+                    .height(60.dp)
                     .weight(1f),
             value = data,
             onValueChange = { input ->
@@ -124,18 +124,30 @@ fun TalkInput(onClicked: () -> Unit) {
                 TalkInputDecor(innerTextField)
             }
         )
-        IconButton(
-            modifier =
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .height(60.dp)
+                .width(60.dp)
+        ) {
+            IconButton(
+                colors = IconButtonDefaults.iconButtonColors(
+                    containerColor = Grey3,
+                    contentColor = Black
+                ),
+                modifier =
                 Modifier
                     .height(50.dp)
                     .width(50.dp),
-            onClick = onClicked
-        ) {
-            Icon(
-                imageVector = Icons.Filled.Send,
-                contentDescription = "Send Button"
-            )
+                onClick = onClicked
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Send,
+                    contentDescription = "Send Button"
+                )
+            }
         }
+
     }
 }
 
@@ -160,7 +172,7 @@ fun TalkInputDecor(innerTextField: @Composable () -> Unit) {
                 contentAlignment = Alignment.CenterStart,
                 modifier = Modifier
                     .fillMaxSize()
-                    .padding(all = 5.dp),
+                    .padding(start = 10.dp, end = 10.dp, top = 5.dp, bottom = 5.dp),
             ) {
                 innerTextField()
             }

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -3,6 +3,12 @@ package com.gdsc_cau.vridge.talk
 import androidx.compose.runtime.Composable
 import com.gdsc_cau.vridge.main.Greeting
 
+private enum class VoiceState {
+    VOICE_LOADING,
+    VOICE_PLAYING,
+    VOICE_READY
+}
+
 @Composable
 fun TalkScreen(
     sessionId: String

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.CardDefaults
@@ -42,10 +43,16 @@ fun TalkCard() {
             ),
         modifier =
             Modifier
-                .fillMaxWidth()
                 .background(color = Color.White)
+                .fillMaxWidth()
+                .padding(all = 15.dp)
     ) {
-        Text(text = "Talk Card")
+        Text(
+            modifier =
+                Modifier
+                    .padding(all = 15.dp),
+            text = "This is Talk Card Content"
+        )
     }
 }
 

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -1,6 +1,13 @@
 package com.gdsc_cau.vridge.talk
 
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import com.gdsc_cau.vridge.main.Greeting
 
 private enum class VoiceState {
@@ -14,4 +21,20 @@ fun TalkScreen(
     sessionId: String
 ) {
     Greeting(name = "Talk $sessionId")
+}
+
+@Composable
+fun TalkCard() {
+    ElevatedCard(
+        elevation =
+            CardDefaults.cardElevation(
+                defaultElevation = 6.dp
+            ),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(40.dp)
+    ) {
+        Text(text = "Talk Card")
+    }
 }

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.gdsc_cau.vridge.ui.theme.Black
 import com.gdsc_cau.vridge.ui.theme.White
@@ -38,9 +39,10 @@ private enum class VoiceState {
     VOICE_READY
 }
 
+@Preview
 @Composable
 fun TalkScreen(
-    sessionId: String
+//    sessionId: String
 ) {
     TalkHistory()
     TalkInput {}

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -1,6 +1,7 @@
 package com.gdsc_cau.vridge.talk
 
 import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,6 +18,7 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -25,8 +27,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.gdsc_cau.vridge.ui.theme.Black
+import com.gdsc_cau.vridge.ui.theme.White
 
 private enum class VoiceState {
     VOICE_LOADING,
@@ -48,7 +51,7 @@ fun TalkHistory() {
         modifier =
             Modifier
                 .fillMaxSize()
-                .padding(bottom = 45.dp)
+                .padding(bottom = 55.dp)
                 .verticalScroll(ScrollState(Int.MAX_VALUE)),
         verticalArrangement = Arrangement.Bottom
     ) {
@@ -72,8 +75,8 @@ private fun TalkCard(talkData: String, talkState: VoiceState) {
     ElevatedCard(
         colors =
             CardDefaults.cardColors(
-                containerColor = Color.White,
-                contentColor = Color.Black
+                containerColor = White,
+                contentColor = Black
             ),
         elevation =
             CardDefaults.cardElevation(
@@ -122,6 +125,7 @@ fun TalkInput(onClicked: () -> Unit) {
             modifier =
                 Modifier
                     .height(45.dp)
+                    .padding(all = 5.dp)
                     .width(45.dp),
             onClick = onClicked
         ) {
@@ -138,6 +142,19 @@ fun TalkInputDecor(innerTextField: @Composable () -> Unit) {
     Row(
         verticalAlignment = Alignment.CenterVertically
     ) {
-        innerTextField()
+        OutlinedCard(
+            colors =
+                CardDefaults.cardColors(
+                    containerColor = White,
+                    contentColor = Black
+                ),
+            modifier =
+                Modifier
+                    .background(White)
+                    .fillMaxSize()
+                    .padding(all = 5.dp)
+        ) {
+            innerTextField()
+        }
     }
 }

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -1,9 +1,9 @@
 package com.gdsc_cau.vridge.talk
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.CardDefaults
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 
 private enum class VoiceState {
@@ -37,12 +38,12 @@ fun TalkCard() {
     ElevatedCard(
         elevation =
             CardDefaults.cardElevation(
-                defaultElevation = 6.dp
+                defaultElevation = 8.dp
             ),
         modifier =
             Modifier
                 .fillMaxWidth()
-                .height(40.dp)
+                .background(color = Color.White)
     ) {
         Text(text = "Talk Card")
     }

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -3,6 +3,7 @@ package com.gdsc_cau.vridge.talk
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -124,9 +125,8 @@ fun TalkInput(onClicked: () -> Unit) {
         IconButton(
             modifier =
                 Modifier
-                    .height(45.dp)
-                    .padding(all = 5.dp)
-                    .width(45.dp),
+                    .height(50.dp)
+                    .width(50.dp),
             onClick = onClicked
         ) {
             Icon(
@@ -154,7 +154,14 @@ fun TalkInputDecor(innerTextField: @Composable () -> Unit) {
                     .fillMaxSize()
                     .padding(all = 5.dp)
         ) {
-            innerTextField()
+            Box(
+                contentAlignment = Alignment.CenterStart,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(all = 5.dp),
+            ) {
+                innerTextField()
+            }
         }
     }
 }

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -16,8 +16,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
@@ -182,7 +180,7 @@ fun TalkInput(onClicked: () -> Unit) {
                 onClick = onClicked
             ) {
                 Icon(
-                    imageVector = Icons.Filled.Send,
+                    painterResource(R.drawable.ic_send),
                     contentDescription = "Send Button"
                 )
             }

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -51,8 +51,7 @@ fun TalkScreen(
 @Composable
 fun TalkHistory() {
     Column(
-        modifier =
-        Modifier
+        modifier = Modifier
             .fillMaxSize()
             .padding(bottom = 75.dp)
             .verticalScroll(ScrollState(Int.MAX_VALUE)),
@@ -85,15 +84,13 @@ private fun TalkCard(talkData: String, talkState: VoiceState) {
             CardDefaults.cardElevation(
                 defaultElevation = 8.dp
             ),
-        modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(all = 15.dp)
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(all = 15.dp)
     ) {
         Text(
-            modifier =
-                Modifier
-                    .padding(all = 15.dp),
+            modifier = Modifier
+                .padding(all = 15.dp),
             text = talkData
         )
     }
@@ -112,10 +109,9 @@ fun TalkInput(onClicked: () -> Unit) {
         verticalAlignment = Alignment.Bottom
     ) {
         BasicTextField(
-            modifier =
-                Modifier
-                    .height(60.dp)
-                    .weight(1f),
+            modifier = Modifier
+                .height(60.dp)
+                .weight(1f),
             value = data,
             onValueChange = { input ->
                 data = input
@@ -135,8 +131,7 @@ fun TalkInput(onClicked: () -> Unit) {
                     containerColor = Grey3,
                     contentColor = Black
                 ),
-                modifier =
-                Modifier
+                modifier = Modifier
                     .height(50.dp)
                     .width(50.dp),
                 onClick = onClicked
@@ -162,11 +157,10 @@ fun TalkInputDecor(innerTextField: @Composable () -> Unit) {
                     containerColor = White,
                     contentColor = Black
                 ),
-            modifier =
-                Modifier
-                    .background(White)
-                    .fillMaxSize()
-                    .padding(all = 5.dp)
+            modifier = Modifier
+                .background(White)
+                .fillMaxSize()
+                .padding(all = 5.dp)
         ) {
             Box(
                 contentAlignment = Alignment.CenterStart,

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -1,5 +1,6 @@
 package com.gdsc_cau.vridge.talk
 
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -14,7 +15,6 @@ import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.gdsc_cau.vridge.main.Greeting
 
 private enum class VoiceState {
     VOICE_LOADING,
@@ -26,7 +26,10 @@ private enum class VoiceState {
 fun TalkScreen(
     sessionId: String
 ) {
-    Greeting(name = "Talk $sessionId")
+    Column {
+        TalkCard()
+        TalkInput {}
+    }
 }
 
 @Composable
@@ -46,7 +49,7 @@ fun TalkCard() {
 }
 
 @Composable
-fun TalkInput(message: String, onClicked: () -> Unit) {
+fun TalkInput(onClicked: () -> Unit) {
     Row {
         TextField(
             value = "",

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -49,7 +49,7 @@ fun TalkScreen(
     sessionId: String
 ) {
     TalkHistory()
-    TalkInput {}
+    TalkInput(onSendClicked = {})
 }
 
 @Composable
@@ -140,7 +140,7 @@ private fun TextCardController(voiceState: VoiceState) {
 }
 
 @Composable
-fun TalkInput(onClicked: () -> Unit) {
+fun TalkInput(onSendClicked: () -> Unit) {
     var data by remember {
         mutableStateOf("")
     }
@@ -177,7 +177,7 @@ fun TalkInput(onClicked: () -> Unit) {
                 modifier = Modifier
                     .height(50.dp)
                     .width(50.dp),
-                onClick = onClicked
+                onClick = onSendClicked
             ) {
                 Icon(
                     painterResource(R.drawable.ic_send),

--- a/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/talk/TalkScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.CardDefaults
@@ -21,7 +22,6 @@ import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonDefaults
-import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -30,11 +30,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.gdsc_cau.vridge.R
 import com.gdsc_cau.vridge.ui.theme.Black
 import com.gdsc_cau.vridge.ui.theme.Grey3
+import com.gdsc_cau.vridge.ui.theme.Grey4
 import com.gdsc_cau.vridge.ui.theme.PrimaryUpperLight
 import com.gdsc_cau.vridge.ui.theme.White
 
@@ -186,19 +188,19 @@ fun TalkInput(onSendClicked: () -> Unit) {
             contentAlignment = Alignment.Center,
             modifier =
                 Modifier
+                    .background(Grey4)
                     .height(60.dp)
                     .width(60.dp)
         ) {
             IconButton(
                 colors =
                     IconButtonDefaults.iconButtonColors(
-                        containerColor = Grey3,
                         contentColor = Black
                     ),
                 modifier =
                     Modifier
-                        .height(50.dp)
-                        .width(50.dp),
+                        .height(40.dp)
+                        .width(40.dp),
                 onClick = onSendClicked
             ) {
                 Icon(
@@ -213,29 +215,24 @@ fun TalkInput(onSendClicked: () -> Unit) {
 @Composable
 fun TalkInputDecor(innerTextField: @Composable () -> Unit) {
     Row(
+        modifier =
+            Modifier
+                .background(Grey4)
+                .padding(start = 10.dp)
+                .padding(vertical = 10.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        OutlinedCard(
-            colors =
-                CardDefaults.cardColors(
-                    containerColor = White,
-                    contentColor = Black
-                ),
+        Box(
+            contentAlignment = Alignment.CenterStart,
             modifier =
                 Modifier
+                    .clip(RoundedCornerShape(8.dp))
                     .background(White)
                     .fillMaxSize()
-                    .padding(all = 5.dp)
+                    .padding(start = 10.dp)
+                    .padding(vertical = 5.dp)
         ) {
-            Box(
-                contentAlignment = Alignment.CenterStart,
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = 10.dp, vertical = 5.dp)
-            ) {
-                innerTextField()
-            }
+            innerTextField()
         }
     }
 }

--- a/app/src/main/res/drawable/ic_downloading.xml
+++ b/app/src/main/res/drawable/ic_downloading.xml
@@ -1,0 +1,5 @@
+<vector android:height="48dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18.32,4.26C16.84,3.05 15.01,2.25 13,2.05v2.02c1.46,0.18 2.79,0.76 3.9,1.62L18.32,4.26zM19.93,11h2.02c-0.2,-2.01 -1,-3.84 -2.21,-5.32L18.31,7.1C19.17,8.21 19.75,9.54 19.93,11zM18.31,16.9l1.43,1.43c1.21,-1.48 2.01,-3.32 2.21,-5.32h-2.02C19.75,14.46 19.17,15.79 18.31,16.9zM13,19.93v2.02c2.01,-0.2 3.84,-1 5.32,-2.21l-1.43,-1.43C15.79,19.17 14.46,19.75 13,19.93zM13,12V7h-2v5H7l5,5l5,-5H13zM11,19.93v2.02c-5.05,-0.5 -9,-4.76 -9,-9.95s3.95,-9.45 9,-9.95v2.02C7.05,4.56 4,7.92 4,12S7.05,19.44 11,19.93z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_downloading.xml
+++ b/app/src/main/res/drawable/ic_downloading.xml
@@ -1,5 +1,5 @@
-<vector android:height="48dp" android:tint="#000000"
+<vector android:height="24dp" android:tint="#000000"
     android:viewportHeight="24" android:viewportWidth="24"
-    android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="@android:color/white" android:pathData="M18.32,4.26C16.84,3.05 15.01,2.25 13,2.05v2.02c1.46,0.18 2.79,0.76 3.9,1.62L18.32,4.26zM19.93,11h2.02c-0.2,-2.01 -1,-3.84 -2.21,-5.32L18.31,7.1C19.17,8.21 19.75,9.54 19.93,11zM18.31,16.9l1.43,1.43c1.21,-1.48 2.01,-3.32 2.21,-5.32h-2.02C19.75,14.46 19.17,15.79 18.31,16.9zM13,19.93v2.02c2.01,-0.2 3.84,-1 5.32,-2.21l-1.43,-1.43C15.79,19.17 14.46,19.75 13,19.93zM13,12V7h-2v5H7l5,5l5,-5H13zM11,19.93v2.02c-5.05,-0.5 -9,-4.76 -9,-9.95s3.95,-9.45 9,-9.95v2.02C7.05,4.56 4,7.92 4,12S7.05,19.44 11,19.93z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_play_arrow.xml
+++ b/app/src/main/res/drawable/ic_play_arrow.xml
@@ -1,0 +1,5 @@
+<vector android:height="48dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M8,5v14l11,-7z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_play_arrow.xml
+++ b/app/src/main/res/drawable/ic_play_arrow.xml
@@ -1,5 +1,5 @@
-<vector android:height="48dp" android:tint="#000000"
+<vector android:height="24dp" android:tint="#000000"
     android:viewportHeight="24" android:viewportWidth="24"
-    android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="@android:color/white" android:pathData="M8,5v14l11,-7z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_play_stop.xml
+++ b/app/src/main/res/drawable/ic_play_stop.xml
@@ -1,0 +1,5 @@
+<vector android:height="48dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M6,6h12v12H6z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_play_stop.xml
+++ b/app/src/main/res/drawable/ic_play_stop.xml
@@ -1,5 +1,5 @@
-<vector android:height="48dp" android:tint="#000000"
+<vector android:height="24dp" android:tint="#000000"
     android:viewportHeight="24" android:viewportWidth="24"
-    android:width="48dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
     <path android:fillColor="@android:color/white" android:pathData="M6,6h12v12H6z"/>
 </vector>

--- a/app/src/main/res/drawable/ic_send.xml
+++ b/app/src/main/res/drawable/ic_send.xml
@@ -1,0 +1,5 @@
+<vector android:autoMirrored="true" android:height="24dp"
+    android:tint="#000000" android:viewportHeight="24"
+    android:viewportWidth="24" android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M2.01,21L23,12 2.01,3 2,10l15,2 -15,2z"/>
+</vector>


### PR DESCRIPTION
## Summary
Talk UI를 구성하였습니다.

## Description
- Talk 기능을 위한 UI를 구성하였습니다.
- 크게 `TalkHistory`와 `TalkInput`으로 나뉘어지며, 각각 기존 Talk 데이터 표시와 새 Talk 입력의 역할을 수행합니다.
- `TalkHistory`의 경우, 각각의 Talk 데이터는 `TalkCard` 위젯으로 표현되며, 해당 위젯은 `VoiceState` Enum 속성과 Talk 텍스트 데이터를 속성으로 갖습니다. `VoiceState` 속성에 따라 재생 / 정지 / 로딩 상태가 결정되며, 알맞은 색상과 아이콘이 적용됩니다.
- `TalkHistory`는 일반적인 채팅 UI와 마찬가지로 하단부터 `TalkCard`가 채워지며, Height 값을 넘어서는 경우 세로 스크롤이 활성화됩니다. 이 때, UI Init 시 최하단의 최신 `TalkCard` 부분으로 스크롤 위치가 시작됩니다.
- `TalkCard`의 우측 색상과 아이콘 부분은 `TalkCardController`로 분리되어있으며, 해당 부분의 `Clickable` 속성이 적용되어 있습니다. 해당 부분의 `TODO` 주석을 참고하여 로직을 구현하시면 됩니다.
- `TalkInput`에서도 마찬가지로 `TODO` 주석을 참고하여 로직을 구현하시면 됩니다.

<div style="display: flex; flex-direction: row;">
  <img width="30%" src="https://github.com/GDSC-CAU/Vridge-Android/assets/12806229/6d2422e4-9729-43ec-9a31-081e968dc040"/>
  <img width="30%" src="https://github.com/GDSC-CAU/Vridge-Android/assets/12806229/467d669b-e3a2-412a-b01b-66b4f42b69a9"/>
</div>