### PR TITLE
[FIX] DB에 없는 UID 찾을 때 오류로 인한 강제종료 오류 해결

### DIFF
--- a/app/src/main/java/com/gdsc_cau/vridge/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/profile/ProfileViewModel.kt
@@ -1,22 +1,20 @@
 package com.gdsc_cau.vridge.ui.profile
 
-import android.content.Intent
-import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gdsc_cau.vridge.data.models.User
 import com.gdsc_cau.vridge.data.repository.UserRepository
-import com.gdsc_cau.vridge.ui.main.MainActivity
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class ProfileViewModel @Inject constructor(private val repository: UserRepository) : ViewModel() {
     private val _user = MutableStateFlow(User())
-    val user: StateFlow<User> = _user
+    val user: StateFlow<User> = _user.asStateFlow()
 
     private val _isLoggedOut = MutableStateFlow(false)
     val isLoggedOut: StateFlow<Boolean> = _isLoggedOut
@@ -27,7 +25,11 @@ class ProfileViewModel @Inject constructor(private val repository: UserRepositor
 
     fun getUserInfo() {
         viewModelScope.launch {
-            _user.emit(repository.getUserInfo(repository.getUid()))
+            try {
+                _user.emit(repository.getUserInfo(repository.getUid()))
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Profile 화면 접근시 DB에 해당 uid로 된 데이터가 없을 경우 앱이 강제종료되는 오류를 해결했습니다.

## Description
- InvalidUidException catch 구문 추가
- 추후 SnackBar 처리 예정

#64 