### PR TITLE
[DEV] 전 화면 UiState 사용 및 에러 핸들링 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -75,9 +75,9 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
 
-    implementation("androidx.hilt:hilt-navigation-compose:1.1.0")
-    implementation("com.google.dagger:hilt-android:2.48")
-    kapt("com.google.dagger:hilt-android-compiler:2.48")
+    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
+    implementation("com.google.dagger:hilt-android:2.51.1")
+    kapt("com.google.dagger:hilt-android-compiler:2.51.1")
 
     implementation("com.airbnb.android:lottie-compose:5.0.2")
 

--- a/app/src/main/java/com/gdsc_cau/vridge/data/models/Tts.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/data/models/Tts.kt
@@ -4,4 +4,5 @@ data class Tts(
     val id: String,
     val text: String,
     val timestamp: Long,
+    val state: Boolean = false
 )

--- a/app/src/main/java/com/gdsc_cau/vridge/data/repository/DefaultVoiceRepository.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/data/repository/DefaultVoiceRepository.kt
@@ -9,9 +9,6 @@ import com.gdsc_cau.vridge.data.dto.VoiceDTO
 import com.gdsc_cau.vridge.data.models.Voice
 import com.google.firebase.auth.FirebaseAuth
 import dagger.hilt.android.qualifiers.ApplicationContext
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 import java.io.FileInputStream
 import java.util.UUID
 import javax.inject.Inject
@@ -38,7 +35,7 @@ constructor(
     private var vid: String? = null
     private var path: String? = null
 
-    override fun getTrainingText(index: Int): String {
+    override fun getScript(index: Int): String {
         if (index < 1 || index > scripts.size)
             return ""
         return scripts[index - 1]
@@ -48,13 +45,13 @@ constructor(
         return scripts.size
     }
 
-    override suspend fun beforeRecord(path: String): Boolean {
+    override suspend fun setFileName(path: String): Boolean {
         vid = UUID.randomUUID().toString().replace("-", "")
         this.path = path
         return true
     }
 
-    override suspend fun saveVoice(index: Int): Boolean {
+    override suspend fun setFile(index: Int): Boolean {
         val uid = getUid() ?: return false
         val vid = this.vid ?: return false
         val fileName = "$path/$index.m4a"
@@ -64,7 +61,7 @@ constructor(
         return storage.uploadFile(uid, vid, "$index.m4a", data)
     }
 
-    override suspend fun afterRecord(name: String, pitch: Float): Boolean {
+    override suspend fun finishRecord(name: String, pitch: Float): Boolean {
         val uid = getUid() ?: return false
         val vid = this.vid ?: return false
         val data = VoiceDTO(uid, vid)

--- a/app/src/main/java/com/gdsc_cau/vridge/data/repository/VoiceRepository.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/data/repository/VoiceRepository.kt
@@ -4,11 +4,11 @@ import com.gdsc_cau.vridge.data.models.Voice
 import kotlinx.coroutines.flow.Flow
 
 interface VoiceRepository {
-    fun getTrainingText(index: Int): String
+    fun getScript(index: Int): String
     fun getScriptSize(): Int
-    suspend fun beforeRecord(path: String): Boolean
-    suspend fun saveVoice(index: Int): Boolean
-    suspend fun afterRecord(name: String, pitch: Float): Boolean
+    suspend fun setFileName(path: String): Boolean
+    suspend fun setFile(index: Int): Boolean
+    suspend fun finishRecord(name: String, pitch: Float): Boolean
     suspend fun synthesize(vid: List<String>): String
     suspend fun getVoiceList(): List<Voice>
 }

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/main/MainActivity.kt
@@ -42,8 +42,11 @@ class MainActivity : ComponentActivity() {
         requestPermissionLauncher.launch(permissions)
 
         setContent {
+            val navigator: MainNavigator = rememberMainNavigator()
             VridgeTheme {
-                MainScreen()
+                MainScreen(
+                    navigator = navigator
+                )
             }
         }
     }

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/main/MainScreen.kt
@@ -43,7 +43,10 @@ fun MainScreen(
         coroutineScope.launch {
             val message = when (throwable) {
                 is UnknownHostException -> localContextResource.getString(R.string.error_message_network)
-                else -> localContextResource.getString(R.string.error_message_unknown)
+                else -> {
+                    if (throwable?.message != null) localContextResource.getString(R.string.error_message_unknown) + "\n" + throwable.message
+                    else { localContextResource.getString(R.string.error_message_unknown) }
+                }
             }
             snackBarHostState.showSnackbar(message)
         }

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/main/MainScreen.kt
@@ -57,7 +57,6 @@ fun MainScreen(
                     .fillMaxSize()
                     .background(MaterialTheme.colorScheme.background)
                     .padding(padding)
-                    .padding(vertical = 8.dp)
             ) {
                 NavHost(
                     navController = navigator.navController,

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/main/MainScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/main/MainScreen.kt
@@ -72,7 +72,7 @@ fun MainScreen(
                         )
                     }
                     composable(RecordRoute.route) {
-                        RecordScreen(
+                        RecordRoute(
                             onBackClick = { navigator.popBackStackIfNotHome() },
                             onShowErrorSnackBar = onShowErrorSnackBar
                         )

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/profile/ProfileUiState.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/profile/ProfileUiState.kt
@@ -1,0 +1,18 @@
+package com.gdsc_cau.vridge.ui.profile
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+import com.gdsc_cau.vridge.data.models.User
+
+@Stable
+sealed interface ProfileUiState {
+
+    @Immutable
+    data object Loading : ProfileUiState
+
+    @Immutable
+    data class Success(
+        val user: User = User(),
+        val isLoggedOut: Boolean = false
+    ) : ProfileUiState
+}

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/profile/ProfileViewModel.kt
@@ -1,5 +1,6 @@
 package com.gdsc_cau.vridge.ui.profile
 
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gdsc_cau.vridge.data.repository.UserRepository
@@ -35,6 +36,7 @@ class ProfileViewModel @Inject constructor(
                     isLoggedOut = false
                 )
             }.catch { throwable ->
+                Log.e("VRIDGE-ProfileVM", throwable.message.toString())
                 _errorFlow.emit(throwable)
             }.collect { _uiState.value = it }
         }

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/record/RecordScreen.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/record/RecordScreen.kt
@@ -55,7 +55,11 @@ import com.gdsc_cau.vridge.ui.util.TopBarType
 import com.gdsc_cau.vridge.ui.util.VridgeTopBar
 
 @Composable
-fun RecordScreen(onBackClick: () -> Unit, viewModel: RecordViewModel = hiltViewModel()) {
+fun RecordScreen(
+    onBackClick: () -> Unit,
+    onShowErrorSnackBar: (Throwable?) -> Unit,
+    viewModel: RecordViewModel = hiltViewModel()
+) {
     val index = viewModel.recordIndex.collectAsStateWithLifecycle().value
     val text = viewModel.recordText.collectAsStateWithLifecycle().value
     val isRecorded = viewModel.isRecorded.collectAsStateWithLifecycle().value

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/record/RecordUiState.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/record/RecordUiState.kt
@@ -12,8 +12,7 @@ sealed interface RecordUiState {
     data class Success(
         val index: Int,
         val text: String,
-        val isRecording: Boolean,
-        val isFinished: Boolean,
-        val isLoading: Boolean
+        val size: Int,
+        val state: RecordState
     ) : RecordUiState
 }

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/record/RecordUiState.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/record/RecordUiState.kt
@@ -1,0 +1,4 @@
+package com.gdsc_cau.vridge.ui.record
+
+interface RecordUiState {
+}

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/record/RecordUiState.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/record/RecordUiState.kt
@@ -1,4 +1,19 @@
 package com.gdsc_cau.vridge.ui.record
 
-interface RecordUiState {
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.Stable
+
+@Stable
+sealed interface RecordUiState {
+    @Immutable
+    data object Loading : RecordUiState
+
+    @Immutable
+    data class Success(
+        val index: Int,
+        val text: String,
+        val isRecording: Boolean,
+        val isFinished: Boolean,
+        val isLoading: Boolean
+    ) : RecordUiState
 }

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/record/RecordViewModel.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/record/RecordViewModel.kt
@@ -117,8 +117,10 @@ class RecordViewModel @Inject constructor(
 
     fun stopPlay() {
         viewModelScope.launch {
+            player?.stop()
             player?.release()
             player = null
+            _recordState.emit(RecordState.RECORDED)
         }
     }
 
@@ -128,6 +130,7 @@ class RecordViewModel @Inject constructor(
             if (uiState.value is RecordUiState.Success) {
                 uiState.value.let {
                     if (index == size) {
+                        _recordState.emit(RecordState.FINISHING)
                         return@launch
                     }
                 }

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/record/RecordViewModel.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/record/RecordViewModel.kt
@@ -7,7 +7,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.gdsc_cau.vridge.data.repository.VoiceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.io.IOException
@@ -33,6 +35,12 @@ class RecordViewModel @Inject constructor(
 
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading
+
+    private val _errorFlow = MutableSharedFlow<Throwable>()
+    val errorFlow: SharedFlow<Throwable> get() = _errorFlow
+
+    private val _uiState = MutableStateFlow<RecordUiState>(RecordUiState.Loading)
+    val uiState: StateFlow<RecordUiState> = _uiState
 
     private var recorder: MediaRecorder? = null
     private var player: MediaPlayer? = null
@@ -118,11 +126,10 @@ class RecordViewModel @Inject constructor(
 
             try {
                 prepare()
+                start()
             } catch (e: Exception) {
                 Log.e(LOG_TAG, "prepare() failed")
             }
-
-            start()
         }
     }
 

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/record/RecordViewModel.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/record/RecordViewModel.kt
@@ -5,36 +5,30 @@ import android.media.MediaRecorder
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.gdsc_cau.vridge.data.repository.VoiceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import java.io.IOException
 import javax.inject.Inject
-
-val LOG_TAG = "RecordViewModel"
 
 @HiltViewModel
 class RecordViewModel @Inject constructor(
     private val repository: VoiceRepository
 ) : ViewModel() {
-    private val _recordIndex = MutableStateFlow(1)
-    val recordIndex: StateFlow<Int> = _recordIndex
+    private val _recordContent = MutableStateFlow(Pair(1, repository.getScript(1)))
+    private val recordContent: StateFlow<Pair<Int, String>> = _recordContent
 
-    private val _recordText = MutableStateFlow(repository.getTrainingText(recordIndex.value))
-    val recordText: StateFlow<String> = _recordText
+    private val index: Int get() = recordContent.value.first
 
-    private val _isRecorded = MutableStateFlow(false)
-    val isRecorded: StateFlow<Boolean> = _isRecorded
-
-    private val _finished = MutableStateFlow(false)
-    val finished: StateFlow<Boolean> = _finished
-
-    private val _isLoading = MutableStateFlow(false)
-    val isLoading: StateFlow<Boolean> = _isLoading
+    private val _recordState = MutableStateFlow(RecordState.IDLE)
+    private val recordState: StateFlow<RecordState> = _recordState
 
     private val _errorFlow = MutableSharedFlow<Throwable>()
     val errorFlow: SharedFlow<Throwable> get() = _errorFlow
@@ -48,101 +42,112 @@ class RecordViewModel @Inject constructor(
     private lateinit var fileDir: String
     private lateinit var fileName: String
 
-    val scriptSize = repository.getScriptSize()
+    private val size = repository.getScriptSize()
+
+    init {
+        viewModelScope.launch {
+            combine(recordContent, recordState) { content, state ->
+                RecordUiState.Success(content.first, content.second, size, state)
+            }.catch {
+                _errorFlow.emit(it)
+            }.collect {
+                _uiState.emit(it)
+            }
+        }
+    }
 
     fun setFileName(name: String) {
         viewModelScope.launch {
             fileDir = name
-            fileName = "$fileDir/${recordIndex.value}.m4a"
-            repository.beforeRecord(fileDir)
-            Log.d(LOG_TAG, "fileDir: $fileDir, fileName: $fileName")
+            fileName = "$fileDir/$index.m4a"
+            repository.setFileName(fileDir)
         }
     }
 
-    fun getNextText() {
+    fun startRecord(recorder: MediaRecorder) {
         viewModelScope.launch {
-            _isLoading.emit(true)
-            val result = repository.saveVoice(recordIndex.value)
-            if (result) {
-                _recordIndex.emit(recordIndex.value + 1)
-                fileName = "$fileDir/${recordIndex.value}.m4a"
-                _recordText.emit(repository.getTrainingText(recordIndex.value))
-                _isRecorded.emit(false)
+            _recordState.emit(RecordState.RECORDING)
+            this@RecordViewModel.recorder = recorder.apply {
+                setAudioSource(MediaRecorder.AudioSource.MIC)
+                setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
+                setOutputFile(fileName)
+                setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB)
             }
-            _isLoading.emit(false)
-        }
-    }
-
-    fun confirmVoice(name: String, pitch: Float) {
-        viewModelScope.launch {
-            _isLoading.emit(true)
-            _finished.emit(repository.afterRecord(name, pitch))
-            _isLoading.emit(false)
-        }
-    }
-
-
-    fun onRecord(start: Boolean, recorder: MediaRecorder? = null) {
-        viewModelScope.launch {
-            if (start) {
-                this@RecordViewModel.recorder = recorder
-                startRecording()
-            } else {
-                stopRecording()
-                _isRecorded.emit(true)
-            }
-        }
-    }
-
-    fun onPlay(start: Boolean) = if (start) {
-        startPlaying()
-    } else {
-        stopPlaying()
-    }
-
-    private fun startPlaying() {
-        player = MediaPlayer().apply {
             try {
-                setDataSource(fileName)
-                prepare()
-                start()
-            } catch (e: IOException) {
-                Log.e(LOG_TAG, "prepare() failed")
-            }
-        }
-    }
-
-    private fun stopPlaying() {
-        player?.release()
-        player = null
-    }
-
-    private fun startRecording() {
-        recorder?.apply {
-            setAudioSource(MediaRecorder.AudioSource.MIC)
-            setOutputFormat(MediaRecorder.OutputFormat.MPEG_4)
-            setOutputFile(fileName)
-            setAudioEncoder(MediaRecorder.AudioEncoder.AMR_NB)
-
-            try {
-                prepare()
-                start()
+                recorder.prepare()
+                recorder.start()
             } catch (e: Exception) {
-                Log.e(LOG_TAG, "prepare() failed")
+                _errorFlow.emit(e)
+                _recordState.emit(RecordState.IDLE)
             }
         }
     }
 
-    private fun stopRecording(): Boolean {
-        try {
-            recorder?.let {
-                it.stop()
-                it.release()
-                return true
-            } ?: return false
-        } catch (e: Exception) {
-            Log.e(LOG_TAG, "stopRecording() failed")
-            return false
+    fun stopRecord() {
+        viewModelScope.launch {
+            try {
+                recorder?.let {
+                    it.stop()
+                    it.release()
+                    recorder = null
+                    _recordState.emit(RecordState.RECORDED)
+                } ?: throw IllegalStateException("Recorder is not initialized")
+            } catch (e: Exception) {
+                _recordState.emit(RecordState.IDLE)
+                _errorFlow.emit(e)
+            }
+        }
+    }
+
+    fun startPlay() {
+        viewModelScope.launch {
+            try {
+                player = MediaPlayer().apply {
+                    _recordState.emit(RecordState.PLAYING)
+                    setDataSource(fileName)
+                    this.prepare()
+                    this.start()
+                }
+            } catch (e: IOException) {
+                _recordState.emit(RecordState.RECORDED)
+                _errorFlow.emit(e)
+            }
+        }
+    }
+
+    fun stopPlay() {
+        viewModelScope.launch {
+            player?.release()
+            player = null
+        }
+    }
+
+    fun getNext() {
+        viewModelScope.launch {
+            _recordState.emit(RecordState.LOADING)
+            if (uiState.value is RecordUiState.Success) {
+                uiState.value.let {
+                    if (index == size) {
+                        return@launch
+                    }
+                }
+            }
+            if (repository.setFile(index)) {
+                fileName = "$fileDir/${index + 1}}.m4a"
+                _recordContent.emit(Pair(index + 1, repository.getScript(index + 1)))
+                _recordState.emit(RecordState.IDLE)
+            }
+        }
+    }
+
+    fun finishRecord(name: String, pitch: Float) {
+        viewModelScope.launch {
+            _recordState.emit(RecordState.LOADING)
+            if (repository.finishRecord(name, pitch)) {
+                _recordState.emit(RecordState.FINISHED)
+            } else {
+                _recordState.emit(RecordState.RECORDED)
+            }
         }
     }
 }

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/record/VoiceSettingDialog.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/record/VoiceSettingDialog.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
@@ -29,10 +30,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.gdsc_cau.vridge.ui.theme.OnPrimary
+import com.gdsc_cau.vridge.ui.theme.OnPrimaryLight
 import com.gdsc_cau.vridge.ui.theme.Primary
 import com.gdsc_cau.vridge.ui.theme.PrimaryDark
 import com.gdsc_cau.vridge.ui.theme.PrimaryLight
@@ -41,16 +44,20 @@ import com.gdsc_cau.vridge.ui.theme.PrimaryLight
 fun VoiceSettingDialog(
     isShowingDialog: Boolean,
     onConfirmRequest: () -> Unit,
+    onDismissRequest: () -> Unit,
     text: String,
     onTextChanged: (String) -> Unit,
     sliderPosition: Float,
     onSliderChanged: (Float) -> Unit,
     dismissOnBackPress: Boolean = true,
-    dismissOnClickOutside: Boolean = false
+    dismissOnClickOutside: Boolean = true
 ) {
     if (isShowingDialog) {
         Dialog(
-            onDismissRequest = { },
+            onDismissRequest = {
+                onDismissRequest()
+                return@Dialog
+            },
             DialogProperties(
                 dismissOnBackPress = dismissOnBackPress,
                 dismissOnClickOutside = dismissOnClickOutside
@@ -62,7 +69,10 @@ fun VoiceSettingDialog(
                 sliderPosition = sliderPosition,
                 onSliderChanged = onSliderChanged,
                 onConfirmRequest = onConfirmRequest,
-                onDismissRequest = { return@DialogContent }
+                onDismissRequest = {
+                    onDismissRequest()
+                    return@DialogContent
+                }
             )
         }
     }
@@ -87,7 +97,7 @@ fun DialogContent(
             )
             .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.SpaceEvenly
+        verticalArrangement = Arrangement.SpaceBetween
     ) {
         OutlinedTextField(
             label = { Text("Voice Name") },
@@ -117,14 +127,34 @@ fun DialogContent(
             horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Button(onClick = onDismissRequest) {
-                Text("Cancel", color = OnPrimary)
+            Button(
+                onClick = onDismissRequest,
+                colors = ButtonDefaults.buttonColors(containerColor = PrimaryLight)) {
+                Text("Cancel", color = OnPrimaryLight)
             }
             Button(onClick = {
                 onConfirmRequest()
-            }, enabled = text != "", modifier = Modifier.padding(start = 16.dp)) {
+            }, enabled = text != "",
+                modifier = Modifier.padding(start = 16.dp),
+                colors = ButtonDefaults.buttonColors(containerColor = Primary)) {
                 Text("Confirm", color = OnPrimary)
             }
         }
     }
+}
+
+@Composable
+@Preview
+fun VoiceSettingDialogPreview() {
+    var text by remember { mutableStateOf("Voice Name") }
+    var sliderPosition by remember { mutableFloatStateOf(0f) }
+    VoiceSettingDialog(
+        isShowingDialog = true,
+        onConfirmRequest = { },
+        onDismissRequest = { },
+        text = text,
+        onTextChanged = { text = it },
+        sliderPosition = sliderPosition,
+        onSliderChanged = { sliderPosition = it }
+    )
 }

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/record/VoiceSettingDialog.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/record/VoiceSettingDialog.kt
@@ -41,8 +41,10 @@ import com.gdsc_cau.vridge.ui.theme.PrimaryLight
 fun VoiceSettingDialog(
     isShowingDialog: Boolean,
     onConfirmRequest: () -> Unit,
-    text: MutableState<String>,
-    sliderPosition: MutableState<Float>,
+    text: String,
+    onTextChanged: (String) -> Unit,
+    sliderPosition: Float,
+    onSliderChanged: (Float) -> Unit,
     dismissOnBackPress: Boolean = true,
     dismissOnClickOutside: Boolean = false
 ) {
@@ -56,7 +58,9 @@ fun VoiceSettingDialog(
         ) {
             DialogContent(
                 text = text,
+                onTextChanged = onTextChanged,
                 sliderPosition = sliderPosition,
+                onSliderChanged = onSliderChanged,
                 onConfirmRequest = onConfirmRequest,
                 onDismissRequest = { return@DialogContent }
             )
@@ -66,8 +70,10 @@ fun VoiceSettingDialog(
 
 @Composable
 fun DialogContent(
-    text: MutableState<String>,
-    sliderPosition: MutableState<Float>,
+    text: String,
+    onTextChanged: (String) -> Unit,
+    sliderPosition: Float,
+    onSliderChanged: (Float) -> Unit,
     onConfirmRequest: () -> Unit,
     onDismissRequest: () -> Unit
 ) {
@@ -78,22 +84,24 @@ fun DialogContent(
             .background(
                 color = Color.White,
                 shape = RoundedCornerShape(8.dp)
-            ).padding(16.dp),
+            )
+            .padding(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.SpaceEvenly
     ) {
         OutlinedTextField(
-            label = {
-                Text("Voice Name")
-            }, value = text.value, onValueChange = { text.value = it })
+            label = { Text("Voice Name") },
+            value = text,
+            onValueChange = onTextChanged
+        )
         Row(horizontalArrangement = Arrangement.SpaceBetween) {
             Text("Man")
             Text("Woman")
         }
         Slider(
             modifier = Modifier.padding(horizontal = 16.dp),
-            value = sliderPosition.value,
-            onValueChange = { sliderPosition.value = it },
+            value = sliderPosition,
+            onValueChange = onSliderChanged,
             colors = SliderDefaults.colors(
                 thumbColor = PrimaryDark,
                 activeTrackColor = PrimaryDark,
@@ -109,10 +117,12 @@ fun DialogContent(
             horizontalArrangement = Arrangement.End,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Button(onClick = onDismissRequest, enabled = text.value != "") {
+            Button(onClick = onDismissRequest) {
                 Text("Cancel", color = OnPrimary)
             }
-            Button(onClick = onConfirmRequest, modifier = Modifier.padding(start = 16.dp)) {
+            Button(onClick = {
+                onConfirmRequest()
+            }, enabled = text != "", modifier = Modifier.padding(start = 16.dp)) {
                 Text("Confirm", color = OnPrimary)
             }
         }

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/talk/TalkUiState.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/talk/TalkUiState.kt
@@ -1,0 +1,10 @@
+package com.gdsc_cau.vridge.ui.talk
+
+import com.gdsc_cau.vridge.data.models.Tts
+
+sealed interface TalkUiState {
+    data object Loading: TalkUiState
+    data class Success(
+        val talks: List<Tts>
+    ): TalkUiState
+}

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/talk/TalkViewModel.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/talk/TalkViewModel.kt
@@ -3,19 +3,13 @@ package com.gdsc_cau.vridge.ui.talk
 import android.media.AudioAttributes
 import android.media.MediaPlayer
 import android.util.Log
-import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.gdsc_cau.vridge.data.models.Tts
 import com.gdsc_cau.vridge.data.repository.TalkRepository
-import com.gdsc_cau.vridge.ui.record.LOG_TAG
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -25,7 +19,6 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import java.io.IOException
-import javax.inject.Inject
 
 @HiltViewModel(assistedFactory = TalkViewModel.TalkViewModelFactory::class)
 class TalkViewModel @AssistedInject constructor(
@@ -79,7 +72,7 @@ class TalkViewModel @AssistedInject constructor(
                     prepare()
                     start()
                 } catch (e: IOException) {
-                    Log.e(LOG_TAG, "prepare() failed")
+                    _errorFlow.emit(e)
                 }
             }
         }

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/voicelist/VoiceListUiState.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/voicelist/VoiceListUiState.kt
@@ -1,0 +1,11 @@
+package com.gdsc_cau.vridge.ui.voicelist
+
+import com.gdsc_cau.vridge.data.models.Voice
+
+sealed interface VoiceListUiState {
+    data object Loading : VoiceListUiState
+    data object Empty : VoiceListUiState
+    data class Success(
+        val voiceList: List<Voice>
+    ) : VoiceListUiState
+}

--- a/app/src/main/java/com/gdsc_cau/vridge/ui/voicelist/VoiceListViewModel.kt
+++ b/app/src/main/java/com/gdsc_cau/vridge/ui/voicelist/VoiceListViewModel.kt
@@ -31,6 +31,9 @@ class VoiceListViewModel @Inject constructor(
             flow {
                 emit(repository.getVoiceList())
             }.map { voiceList ->
+                if (voiceList.isEmpty())
+                    VoiceListUiState.Empty
+                else
                 VoiceListUiState.Success(
                     voiceList = voiceList
                 )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,7 @@
     <string name="record_btn_play">Play</string>
     <string name="record_btn_stop">Stop</string>
     <string name="record_btn_finish">Finish</string>
+
+    <string name="error_message_network">Network issue occurred.</string>
+    <string name="error_message_unknown">Unknown error occurred.</string>
 </resources>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:8.2.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
-        classpath("com.google.dagger:hilt-android-gradle-plugin:2.48")
+        classpath("com.google.dagger:hilt-android-gradle-plugin:2.51.1")
         classpath("org.jetbrains.kotlin:kotlin-serialization:1.4.10")
     }
 }


### PR DESCRIPTION
## Summary
전 화면에 대해 비즈니스 로직을 일관시키기 위해 UiState를 사용하도록 변경했습니다.

## Description
- 각 화면에 필요한 UiState 추가
- UiState 핸들링 로직 각 화면의 ViewModel에 추가
- UiState를 이용한 화면 구성
- ErrorFlow를 이용한 일관된 에러 처리
- Main 화면에서 Error SnackBar 처리

* 현재 데이터가 없고, 아직 백엔드 연결 부분이 변경되지 않아 모든 화면에 대한 확인을 하지 못했습니다.
* 추후 작업과 함께 버그 수정 예정입니다.

closes #65 , closes #72 , closes #74 